### PR TITLE
Adding Verilator lint to actions flow

### DIFF
--- a/.github/workflows/wokwi.yaml
+++ b/.github/workflows/wokwi.yaml
@@ -6,6 +6,10 @@ permissions:
   pages: write
   id-token: write
 
+defaults:
+  run:
+    working-directory: wokwi
+
 env:
   OPENLANE_TAG:   2022.02.23_02.50.41
   OPENLANE_IMAGE_NAME:    efabless/openlane:$(OPENLANE_TAG)

--- a/.github/workflows/wokwi.yaml
+++ b/.github/workflows/wokwi.yaml
@@ -13,6 +13,9 @@ jobs:
         OPENLANE_ROOT:  /home/runner/openlane
         PDK_ROOT:       /home/runner/pdk
         PDK:            sky130A
+        # Verilator pinned against the cocotb compatible version
+        VERILATOR_TAG:        4.106
+        VERILATOR_IMAGE_NAME: verilator/verilator:$(VERILATOR_TAG)
 
     # ubuntu
     runs-on: ubuntu-latest
@@ -32,6 +35,10 @@ jobs:
     # fetch the Verilog from Wokwi API
     - name: fetch Verilog
       run: make fetch
+
+    # run lint to check for gross problems
+    - name: lint Verilog
+      run: make lint
 
     # run the 'harden' rule in the Makefile to use OpenLane to build the GDS
     - name: make GDS
@@ -57,7 +64,7 @@ jobs:
             print(f'| { "|".join(["-----"] * len(keys)) } |')
             print(f'| { "|".join(report[k] for k in keys) } |')
         EOF
-  
+
     - name: populate src cache
       uses: actions/cache@v2
       with:

--- a/.github/workflows/wokwi.yaml
+++ b/.github/workflows/wokwi.yaml
@@ -38,7 +38,7 @@ jobs:
 
     # run lint to check for gross problems
     - name: lint Verilog
-      run: make lint LINT_USE_DOCKER=yes LINT_DOCKER_TAG=$(VERILATOR_TAG) LINT_DOCKER_IMG=$(VERILATOR_IMAGE_NAME)
+      run: make lint LINT_USE_DOCKER=yes LINT_DOCKER_TAG=$VERILATOR_TAG LINT_DOCKER_IMG=$VERILATOR_IMAGE_NAME
 
     # run the 'harden' rule in the Makefile to use OpenLane to build the GDS
     - name: make GDS

--- a/.github/workflows/wokwi.yaml
+++ b/.github/workflows/wokwi.yaml
@@ -5,18 +5,19 @@ permissions:
   contents: write
   pages: write
   id-token: write
-jobs:
-  gds:
-    env:
-        OPENLANE_TAG:   2022.02.23_02.50.41
-        OPENLANE_IMAGE_NAME:    efabless/openlane:$(OPENLANE_TAG)
-        OPENLANE_ROOT:  /home/runner/openlane
-        PDK_ROOT:       /home/runner/pdk
-        PDK:            sky130A
-        # Verilator pinned against the cocotb compatible version
-        VERILATOR_TAG:        4.106
-        VERILATOR_IMAGE_NAME: verilator/verilator:$(VERILATOR_TAG)
 
+env:
+  OPENLANE_TAG:   2022.02.23_02.50.41
+  OPENLANE_IMAGE_NAME:    efabless/openlane:$(OPENLANE_TAG)
+  OPENLANE_ROOT:  /home/runner/openlane
+  PDK_ROOT:       /home/runner/pdk
+  PDK:            sky130A
+  # Verilator pinned against the cocotb compatible version
+  VERILATOR_TAG:        4.106
+  VERILATOR_IMAGE_NAME: verilator/verilator:$(VERILATOR_TAG)
+
+jobs:
+  bootstrap:
     # ubuntu
     runs-on: ubuntu-latest
     steps:
@@ -36,10 +37,20 @@ jobs:
     - name: fetch Verilog
       run: make fetch
 
+  lint:
+    # ubuntu
+    runs-on: ubuntu-latest
+    needs: [bootstrap]
+    steps:
     # run lint to check for gross problems
     - name: lint Verilog
       run: make lint LINT_USE_DOCKER=yes LINT_DOCKER_TAG=$VERILATOR_TAG LINT_DOCKER_IMG=$VERILATOR_IMAGE_NAME
 
+  gds:
+    # ubuntu
+    runs-on: ubuntu-latest
+    needs: [bootstrap]
+    steps:
     # run the 'harden' rule in the Makefile to use OpenLane to build the GDS
     - name: make GDS
       run: make harden

--- a/.github/workflows/wokwi.yaml
+++ b/.github/workflows/wokwi.yaml
@@ -38,7 +38,7 @@ jobs:
 
     # run lint to check for gross problems
     - name: lint Verilog
-      run: make lint
+      run: make lint LINT_USE_DOCKER=yes LINT_DOCKER_TAG=$(VERILATOR_TAG) LINT_DOCKER_IMG=$(VERILATOR_IMAGE_NAME)
 
     # run the 'harden' rule in the Makefile to use OpenLane to build the GDS
     - name: make GDS

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,30 @@
+
 WOKWI_PROJECT_ID=334445762078310996
+
+# ==============================================================================
+# In most cases, changes don't need to be made below this line
+# ==============================================================================
+
+SRC_DIR        ?= src
+USER_MOD_PATH  ?= $(SRC_DIR)/user_module_$(WOKWI_PROJECT_ID).v
+SCAN_WRAP_PATH ?= $(SRC_DIR)/scan_wrapper_$(WOKWI_PROJECT_ID).v
+CFG_TCL_PATH   ?= $(SRC_DIR)/config.tcl
+PROJ_ID_PATH   ?= $(SRC_DIR)/ID
+
 # logic puzzle and muxes
 # 4 inverters 334348818476696146
 # the clock divider 334335179919196756
+.PHONY: fetch
 fetch:
-	curl https://wokwi.com/api/projects/$(WOKWI_PROJECT_ID)/verilog > src/user_module_$(WOKWI_PROJECT_ID).v
-	sed -e 's/USER_MODULE_ID/$(WOKWI_PROJECT_ID)/g' template/scan_wrapper.v > src/scan_wrapper_$(WOKWI_PROJECT_ID).v
-	sed -e 's/USER_MODULE_ID/$(WOKWI_PROJECT_ID)/g' template/config.tcl > src/config.tcl
-	echo $(WOKWI_PROJECT_ID) > src/ID
+	curl https://wokwi.com/api/projects/$(WOKWI_PROJECT_ID)/verilog > $(USER_MOD_PATH)
+	sed -e 's/USER_MODULE_ID/$(WOKWI_PROJECT_ID)/g' template/scan_wrapper.v > $(SCAN_WRAP_PATH)
+	sed -e 's/USER_MODULE_ID/$(WOKWI_PROJECT_ID)/g' template/config.tcl > $(CFG_TCL_PATH)
+	echo $(WOKWI_PROJECT_ID) > $(PROJ_ID_PATH)
+
+$(USER_MOD_PATH) $(SCAN_WRAP_PATH) $(CFG_TCL_PATH) $(PROJ_ID_PATH): fetch
 
 # needs PDK_ROOT and OPENLANE_ROOT, OPENLANE_IMAGE_NAME set from your environment
+.PHONY: harden
 harden:
 	docker run --rm \
 	-v $(OPENLANE_ROOT):/openlane \
@@ -19,3 +35,46 @@ harden:
 	$(OPENLANE_IMAGE_NAME) \
 	/bin/bash -c "./flow.tcl -overwrite -design /work/src -run_path /work/runs -tag wokwi"
 
+# ==============================================================================
+# Verilator Lint
+# ==============================================================================
+
+# Docker configuration
+LINT_USE_DOCKER ?= yes
+LINT_DOCKER_TAG ?= 4.106
+LINT_DOCKER_IMG ?= verilator/verilator:$(LINT_DOCKER_TAG)
+
+ifeq ($(LINT_USE_DOCKER),yes)
+  LINT_LAUNCH += docker run --rm
+  LINT_LAUNCH += -v $(PDK_ROOT):$(PDK_ROOT):ro
+  LINT_LAUNCH += -v $(CURDIR):$(CURDIR):ro
+  LINT_LAUNCH += -e PDK_ROOT=$(PDK_ROOT)
+  LINT_LAUNCH += -u $(shell id -u $(USER)):$(shell id -g $(USER))
+  LINT_LAUNCH += $(LINT_DOCKER_IMG)
+else
+  LINT_LAUNCH += verilator
+endif
+
+# Run in lint mode
+LINT_ARGS += --lint-only
+# Enable all warnings
+LINT_ARGS += -Wall
+# Blackbox unsupported syntax (required as Verilator doesn't support primitive 'table')
+LINT_ARGS += --bbox-unsup
+# Lint configuration (switch off some warnings)
+LINT_ARGS += $(abspath resources/lint.cfg)
+# Setup the cell library
+LINT_ARGS += -DFUNCTIONAL
+LINT_ARGS += -DUSE_POWER_PINS
+LINT_ARGS += -DUNIT_DELAY=#1
+LINT_ARGS += $(PDK_ROOT)/sky130A/libs.ref/sky130_fd_sc_hd/verilog/primitives.v
+LINT_ARGS += $(PDK_ROOT)/sky130A/libs.ref/sky130_fd_sc_hd/verilog/sky130_fd_sc_hd.v
+LINT_ARGS += $(abspath src/cells.v)
+
+.PHONY: lint
+lint: | $(USER_MOD_PATH) $(SCAN_WRAP_PATH)
+	@echo "# Running Verilator lint on $(USER_MOD_PATH)"
+	$(LINT_LAUNCH) $(LINT_ARGS) \
+	               $(abspath $(USER_MOD_PATH)) \
+	               $(abspath $(SCAN_WRAP_PATH)) \
+	               --top-module scan_wrapper_$(WOKWI_PROJECT_ID)

--- a/resources/lint.cfg
+++ b/resources/lint.cfg
@@ -1,0 +1,11 @@
+`verilator_config
+// NOTE: The intention with this lint setup is to only flag up critical problems
+//       that will prevent successful simulation at chip level, so a bunch of
+//       messages are switched off to avoid scaring the users too much!
+lint_off -rule PINMISSING
+lint_off -rule DECLFILENAME
+lint_off -rule UNUSED
+lint_off -rule UNDRIVEN
+lint_off -rule MULTITOP
+lint_off -rule PINNOCONNECT
+lint_off -rule TIMESCALEMOD


### PR DESCRIPTION
As I found a few problems with designs being indigestible to Verilator, I've added a lint stage to the GitHub actions flow - this uses a docker image pinned to the version that's compatible with cocotb.

This addresses issue #9 